### PR TITLE
Fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Just pass your serial and restore code on the command line :
 
 I'm using this on a little project of mine, an [Online Authenticator for Battle.Net](http://authenticator.me). It is actually in Beta, but I'm planning on launching it soon.
 
+<a href='https://github.com/ymback'>ymback</a> has created a <a href='https://github.com/ymback/Battle.net-Authenticator-Online'>repo</a>, using this as a library on his [Battle.Net Authenticator Online](https://myauth.us). A Chinese-based website.
+
 # Todo
 
 * Sanitize inputs

--- a/classes/Authenticator.php
+++ b/classes/Authenticator.php
@@ -19,7 +19,7 @@ class Authenticator {
 	/**
 	 * @var string format for the Battle.Net servers, %s must be replaced by the region
 	 */
-	static private $server = 'mobile-service.blizzard.com';
+	static private $server = array('eu.battle.net','us.battle.net', 'www.battlenet.com.cn');
 
 	/**
 	 * @var string URI used for initialization
@@ -177,7 +177,7 @@ class Authenticator {
 	 * @return int elapsed time in milliseconds
 	 */
 	public function elapsedtime() {
-		return ($this->servertime() % $this->waitingtime());
+                return fmod(floatval($this->servertime()),$this->waitingtime());
 	}
 
 	/**
@@ -292,7 +292,15 @@ class Authenticator {
 	 * @return string The server address
 	 */
 	private function server() {
-		return sprintf(self::$server, strtolower($this->region()));
+		switch($this->region()){
+                    case self::$accepted_region[0]:
+                        return self::$server[0];
+                    case self::$accepted_region[1]:
+                        return self::$server[1];
+                    case self::$accepted_region[2]:
+                        return self::$server[2];
+		}
+		throw new DataAuthenticatorException('Invalid region provided : '.$this->region().'.');
 	}
 
 	// </editor-fold>


### PR DESCRIPTION
Blizzard use new auth api hosts as the file shows, different region have different api host, actually we can use https to access, in my site, I use curl to access the https api hosts.
The function elapsedtime() in file 'Authenticator.php' has a overflow bug, which may return minus value, fixed.
I have builded a site, modify Authenticator class and use it as a library, so does it possible to add my info to "Who use it" in the README.md.

Signed-off-by: ymback <ymback@sayyoulove.me>